### PR TITLE
Several changes and Travis-CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+sudo: required
+
+services:
+  - docker
+ 
+before_install:
+  - docker build . -t openwrt-kafka:1.0.0
+
+script:
+  - sh tests/test-single-broker.sh
+  - sh tests/test-multiple-brokers.sh
+
+
+   

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,10 +33,4 @@ ADD data/ /data
 
 RUN bash /data/install-kafka.sh
 
-# start container with this script 
-
-ENTRYPOINT ["/docker-entrypoint.sh"]
-
-# with no arguments
- 
-CMD [ "" ]
+CMD [ "/start-kafka-default.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,12 @@ ENV KAFKA_HOME="/opt/kafka"
 ENV KAFKA_USER="kafka"
 ENV KAFKA_GROUP="$KAFKA_USER"
 
+# If no values are set during docker run, then the defaults will be used (see /docker-entrypoint.sh)
+
+ENV KAFKA_CONFIG_FILE=""
+ENV ZOOKEEPER_CONFIG_FILE=""
+ENV ZOO="true"
+
 # installation scripts are here:
 
 RUN mkdir -p /data 

--- a/README.md
+++ b/README.md
@@ -22,16 +22,12 @@ docker build . -t docker-openwrt-kafka:2.11-1.0.0
 
 ## Usage
 
-To run a Kafka server listening on port 9092 execute:
+To run a Kafka server listening on `localhost:9092` execute:
 
 ```
 docker run -p 9092:9092 docker-openwrt-kafka:2.11-1.0.0
 ```
 
-## Warning
+## Tests
 
-GPG Signature **not checked**. 
-
-# Test
-
-A test is under preparation. 
+In `./tests/` you can find some tests which are run after every commit by `travis-ci.org`, as described in `.travis.yml`.

--- a/image/root/docker-entrypoint.sh
+++ b/image/root/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # set -x # uncomment for debugging
-cd /opt/kafka
+cd ${KAFKA_HOME}
 su - kafka
 
 # Start every container with Zookeeper and Kafka running detached. 
@@ -10,5 +10,6 @@ echo "Starting Zookeeper server"
 ((bin/zookeeper-server-start.sh config/zookeeper.properties)&)&
 echo "Starting kafka server"
 ((bin/kafka-server-start.sh config/server.properties)&)&
+
 
 

--- a/image/root/docker-entrypoint.sh
+++ b/image/root/docker-entrypoint.sh
@@ -5,11 +5,34 @@ cd ${KAFKA_HOME}
 su - kafka
 
 # Start every container with Zookeeper and Kafka running detached. 
+# If no configs are set with `docker run -e ....`, use the defaults.
 
-echo "Starting Zookeeper server"
-((bin/zookeeper-server-start.sh config/zookeeper.properties)&)&
-echo "Starting kafka server"
-((bin/kafka-server-start.sh config/server.properties)&)&
+# Zookeeper, if at all
 
+if [ "${ZOO}" != "true" ] #if $ZOO is anything but true (the default), then it's false.
+then
+  echo "Zookeeper set to not start. Please make sure you have configured Kafka to connect to another Zookeeper."
+else
+  if [ ${ZOOKEEPER_CONFIG_FILE} == "" ]
+  then 
+    echo "No Zookeeper-configuration file was given, starting Zookeeper server with the default config/zookeeper.properties"
+    ZOOKEEPER_CONFIG_FILE=config/zookeeper.properties
+  else
+    echo "Starting Zookeeper server with the configuration file ${ZOOKEEPER_CONFIG_FILE}"
+  fi
+  ((bin/zookeeper-server-start.sh "${ZOOKEEPER_CONFIG_FILE}")&)&
+fi
+
+# Kafka
+
+if [ ${KAFKA_CONFIG_FILE} == "" ]
+then 
+  echo "No configuration file given, starting Kafka server with the default config/server.properties"
+  KAFKA_CONFIG_FILE=config/server.properties
+else
+  echo "Starting Kafka server with the configuration file ${KAFKA_CONFIG_FILE}"
+fi
+
+((bin/kafka-server-start.sh "${KAFKA_CONFIG_FILE}")&)&
 
 

--- a/image/root/docker-entrypoint.sh
+++ b/image/root/docker-entrypoint.sh
@@ -1,21 +1,14 @@
 #!/bin/bash
 
-set -x
+# set -x # uncomment for debugging
 cd /opt/kafka
 su - kafka
 
+# Start every container with Zookeeper and Kafka running detached. 
 
-# Add kafka as command if needed
-
-# if no arguments are given to the container, or if the only argument is "kafka"
-if   [[ -z "$1" || ( "$1" = 'kafka' && -z "$2" ) ]] 
-# then start kafka with the default config file I made
-then 
-echo "Starting zookeeper server"
-# run it detached without using disown or nohup
+echo "Starting Zookeeper server"
 ((bin/zookeeper-server-start.sh config/zookeeper.properties)&)&
 echo "Starting kafka server"
-bin/kafka-server-start.sh config/server.properties
-# else just execute the argument that was given at the start of the container.
-else exec $*
-fi
+((bin/kafka-server-start.sh config/server.properties)&)&
+
+

--- a/image/root/start-kafka-default.sh
+++ b/image/root/start-kafka-default.sh
@@ -2,7 +2,6 @@
 
 # set -x # uncomment for debugging
 cd ${KAFKA_HOME}
-su - kafka
 
 # Start every container with Zookeeper and Kafka running detached. 
 # If no configs are set with `docker run -e ....`, use the defaults.
@@ -13,7 +12,7 @@ if [ "${ZOO}" != "true" ] #if $ZOO is anything but true (the default), then it's
 then
   echo "Zookeeper set to not start. Please make sure you have configured Kafka to connect to another Zookeeper."
 else
-  if [ ${ZOOKEEPER_CONFIG_FILE} == "" ]
+  if [ "${ZOOKEEPER_CONFIG_FILE}" == "" ]
   then 
     echo "No Zookeeper-configuration file was given, starting Zookeeper server with the default config/zookeeper.properties"
     ZOOKEEPER_CONFIG_FILE=config/zookeeper.properties
@@ -25,7 +24,7 @@ fi
 
 # Kafka
 
-if [ ${KAFKA_CONFIG_FILE} == "" ]
+if [ "${KAFKA_CONFIG_FILE}" == "" ]
 then 
   echo "No configuration file given, starting Kafka server with the default config/server.properties"
   KAFKA_CONFIG_FILE=config/server.properties
@@ -33,6 +32,8 @@ else
   echo "Starting Kafka server with the configuration file ${KAFKA_CONFIG_FILE}"
 fi
 
-((bin/kafka-server-start.sh "${KAFKA_CONFIG_FILE}")&)&
+# The exec below will make kafka PID 1 of this container. 
+
+exec bin/kafka-server-start.sh "${KAFKA_CONFIG_FILE}"
 
 

--- a/tests/internal/multiple-broker.sh
+++ b/tests/internal/multiple-broker.sh
@@ -8,7 +8,7 @@
 # https://kafka.apache.org/documentation.html#quickstart
 # -------------------------------------------------------------------
 
-# set -x # uncomment for debugging
+set -x # uncomment for debugging
 
 # Expand the cluster to 3 nodes, by adding 2 more brokers.
 
@@ -18,7 +18,9 @@ sed 's/broker.id=0/broker.id=1/1; s/#listeners/listeners/1; s/:9092/:9093/1; s/k
 sed 's/broker.id=0/broker.id=2/1; s/#listeners/listeners/1;  s/:9092/:9094/1; s/kafka-logs/kafka-logs-2/1' config/server.properties > config/server-2.properties
 
 ((bin/kafka-server-start.sh config/server-1.properties)&)&
+PID_SERVER_1=$(echo $!)
 ((bin/kafka-server-start.sh config/server-2.properties)&)&
+PID_SERVER_2=$(echo $!)
 
 # wait until the servers are up
 
@@ -31,10 +33,12 @@ bin/kafka-topics.sh --create --zookeeper localhost:2181 --replication-factor 3 -
 TEST_STRING="$(bin/kafka-topics.sh --describe --zookeeper localhost:2181 --topic my-replicated-topic | sed -n 1p)"
 TEST_RESULT=$'Topic:my-replicated-topic\tPartitionCount:1\tReplicationFactor:3\tConfigs:'
 
+kill $PID_SERVER_1
+kill $PID_SERVER_2
+
 if [ "$TEST_STRING" = "$TEST_RESULT" ] 
 then echo "ok"
+     exit 0
 else echo "not ok"
      exit 1
 fi
-
-

--- a/tests/internal/multiple-broker.sh
+++ b/tests/internal/multiple-broker.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+# -------------------------------------------------------------------
+# This script is intended to be run from inside a docker container 
+# which has Kafka installed and running (standard cmd), to test if the installation works as 
+# described in:
+# 
+# https://kafka.apache.org/documentation.html#quickstart
+# -------------------------------------------------------------------
+
+# set -x # uncomment for debugging
+
+# Expand the cluster to 3 nodes, by adding 2 more brokers.
+
+cd ${KAFKA_HOME}
+
+sed 's/broker.id=0/broker.id=1/1; s/#listeners/listeners/1; s/:9092/:9093/1; s/kafka-logs/kafka-logs-1/1' config/server.properties > config/server-1.properties
+sed 's/broker.id=0/broker.id=2/1; s/#listeners/listeners/1;  s/:9092/:9094/1; s/kafka-logs/kafka-logs-2/1' config/server.properties > config/server-2.properties
+
+
+((bin/kafka-server-start.sh config/server-1.properties)&)&
+bin/kafka-server-start.sh config/server-2.properties &
+
+# wait until the servers are up
+
+sleep 5
+
+# create new topic with replication factor 3
+
+bin/kafka-topics.sh --create --zookeeper localhost:2181 --replication-factor 3 --partitions 1 --topic my-replicated-topic
+
+TEST_STRING="$(bin/kafka-topics.sh --describe --zookeeper localhost:2181 --topic my-replicated-topic | sed -n 1p)"
+TEST_RESULT=$'Topic:my-replicated-topic\tPartitionCount:1\tReplicationFactor:3\tConfigs:'
+
+if [ "$TEST_STRING" = "$TEST_RESULT" ] 
+then echo "ok"
+else echo "not ok"
+     exit 1
+fi
+
+exit 2

--- a/tests/internal/multiple-broker.sh
+++ b/tests/internal/multiple-broker.sh
@@ -33,12 +33,9 @@ bin/kafka-topics.sh --create --zookeeper localhost:2181 --replication-factor 3 -
 TEST_STRING="$(bin/kafka-topics.sh --describe --zookeeper localhost:2181 --topic my-replicated-topic | sed -n 1p)"
 TEST_RESULT=$'Topic:my-replicated-topic\tPartitionCount:1\tReplicationFactor:3\tConfigs:'
 
-kill $PID_SERVER_1
-kill $PID_SERVER_2
-
-if [ "$TEST_STRING" = "$TEST_RESULT" ] 
-then echo "ok"
-     exit 0
-else echo "not ok"
+if [ "$TEST_STRING" != "$TEST_RESULT" ] 
+then echo "not ok"
      exit 1
 fi
+
+

--- a/tests/internal/multiple-broker.sh
+++ b/tests/internal/multiple-broker.sh
@@ -17,9 +17,8 @@ cd ${KAFKA_HOME}
 sed 's/broker.id=0/broker.id=1/1; s/#listeners/listeners/1; s/:9092/:9093/1; s/kafka-logs/kafka-logs-1/1' config/server.properties > config/server-1.properties
 sed 's/broker.id=0/broker.id=2/1; s/#listeners/listeners/1;  s/:9092/:9094/1; s/kafka-logs/kafka-logs-2/1' config/server.properties > config/server-2.properties
 
-
 ((bin/kafka-server-start.sh config/server-1.properties)&)&
-bin/kafka-server-start.sh config/server-2.properties &
+((bin/kafka-server-start.sh config/server-2.properties)&)&
 
 # wait until the servers are up
 
@@ -38,4 +37,4 @@ else echo "not ok"
      exit 1
 fi
 
-exit 2
+

--- a/tests/internal/single-broker.sh
+++ b/tests/internal/single-broker.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+# -------------------------------------------------------------------
+# This script is intended to be run from inside a docker container 
+# which has Kafka installed, to test if the installation works as 
+# described in:
+# 
+# https://kafka.apache.org/documentation.html#quickstart
+# -------------------------------------------------------------------
+
+ set -x # uncomment for debugging
+
+# create a topic named test with a single partition and one replica, using the local zookeeper.
+
+echo "================================"
+
+cd ${KAFKA_HOME}
+pwd
+
+bin/kafka-topics.sh --create --zookeeper localhost:2181 --replication-factor 1 --partitions 1 --topic test
+
+
+# see the test topic
+
+TEST_STRING="$(bin/kafka-topics.sh --list --zookeeper localhost:2181)"
+
+if [ "${TEST_STRING}" != "test" ]
+then 
+  echo "CREATE TEST TOPIC FAILED"
+  exit 1
+fi
+
+# send a message
+
+bin/kafka-console-producer.sh --broker-list localhost:9092 --topic test <<EOF
+this is a test
+EOF
+
+# consume that message
+
+TEST_STRING="$(bin/kafka-console-consumer.sh --bootstrap-server localhost:9092 --topic test --from-beginning --max-messages 1)"
+
+if [ "${TEST_STRING}" != "this is a test" ]
+then 
+  echo "CONSUME MESSAGE FAILED"
+  exit 1
+fi
+
+
+

--- a/tests/test-multiple-brokers.sh
+++ b/tests/test-multiple-brokers.sh
@@ -9,3 +9,4 @@ docker run -d --name multiple -v "${LOCAL_DIR}/tests/internal/multiple-broker.sh
 sleep 5
 
 docker exec multiple sh /opt/kafka/multiple-broker.sh
+

--- a/tests/test-multiple-brokers.sh
+++ b/tests/test-multiple-brokers.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# set -x # uncomment for debugging
+
+LOCAL_DIR="$(pwd)"
+
+docker run -d --name multiple -v "${LOCAL_DIR}/tests/internal/multiple-broker.sh":/opt/kafka/multiple-broker.sh openwrt-kafka:1.0.0
+
+sleep 5
+
+docker exec multiple sh /opt/kafka/multiple-broker.sh

--- a/tests/test-multiple-brokers.sh
+++ b/tests/test-multiple-brokers.sh
@@ -8,5 +8,5 @@ docker run -d --name multiple -v "${LOCAL_DIR}/tests/internal/multiple-broker.sh
 
 sleep 5
 
-docker exec multiple sh /opt/kafka/multiple-broker.sh
+docker exec -it multiple sh /opt/kafka/multiple-broker.sh
 

--- a/tests/test-single-broker.sh
+++ b/tests/test-single-broker.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# set -x # uncomment for debugging
+
+LOCAL_DIR="$(pwd)"
+
+docker run -d --name single -v "${LOCAL_DIR}/tests/internal/single-broker.sh":/opt/kafka/single-broker.sh openwrt-kafka:1.0.0
+
+sleep 5
+
+docker exec single sh /opt/kafka/single-broker.sh


### PR DESCRIPTION
* A typo: /opt/kafka should be $KAFKA_HOME
* Changed entrypoint to cmd, because there are many ways to run this image (zookeeper yes/no and one or more Kafka servers)
* Added variables to control some behaviour of the default "1 zookeeper + 1 Kafka" 
* Created tests which basically follow the Kafka Quickstart guide found here: https://kafka.apache.org/documentation.html#quickstart
* Added .travis.yml to automate these tests with Travis-ci.org. (Note that one might need to restart the build on travis-ci.org after a commit. Even changes to the README.md might break an automated build.)
  